### PR TITLE
Prevent exception when ServerCertificate is null

### DIFF
--- a/UaClient/ServiceModel/Ua/Channels/ClientSessionChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/ClientSessionChannel.cs
@@ -343,7 +343,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                     LocalPrivateKey = tuple.Key;
                 }
             
-                var cert = _certificateParser.ReadCertificate(RemoteCertificate);
+                var cert = RemoteCertificate != null ? _certificateParser.ReadCertificate(RemoteCertificate) : null;
                 RemotePublicKey = cert?.GetPublicKey() as RsaKeyParameters;
 
                 var createSessionRequest = new CreateSessionRequest


### PR DESCRIPTION
When connecting to a server that has no certificate, ClientSessionChannel.OnOpenAsync throws an exception because it tries to read a certificate from an byte array that is null. 

This PR ensures that we only read the certificate if the byte array is not null.